### PR TITLE
Fixed invalid HTTP-request for issue #25

### DIFF
--- a/server_http.hpp
+++ b/server_http.hpp
@@ -297,6 +297,13 @@ namespace SimpleWeb {
                         if(line.substr(path_end+1, protocol_end-path_end-1)!="HTTP")
                             return false;
                         request->http_version=line.substr(protocol_end+1, line.size()-protocol_end-2);
+                        //Check if the HTTP-version is empty. If empty, terminate connection due to invalid HTTP-request.
+                        if (request->http_version == ""){
+                            return false;
+                            //Only allowing the current HTTP-version 1.1
+                        } if (request->http_version != "1.1"){
+                            return false; 
+                        }
                     }
                     else
                         return false;


### PR DESCRIPTION
Solution:
Server only allows current version HTTP-version 1.1. Added a check to see whether the HTTP-version is empty. If empty, the connection to the server is terminated due to malformed request.